### PR TITLE
modify build_emulator for more precise qt version

### DIFF
--- a/script/build_emulator.sh
+++ b/script/build_emulator.sh
@@ -36,7 +36,7 @@ function build_emulator {
     git clone https://github.com/jmodares/UB-ANC-Emulator
     mkdir build-emulator
     cd build-emulator
-    qmake ../UB-ANC-Emulator
+    $BASEDIR/Qt5.7-linux/5.7/gcc_64/bin/qmake ../UB-ANC-Emulator
     make -j4
 }
 
@@ -56,7 +56,7 @@ function build_mission {
     git clone https://github.com/jmodares/follower
     mkdir build-follower
     cd build-follower
-    qmake ../follower
+    $BASEDIR/Qt5.7-linux/5.7/gcc_64/bin/qmake ../follower
     make -j4
 }
 


### PR DESCRIPTION
when I compile the emulator i got a lot of link error .
Finally I use this project's qt to solve, So I think use precise qmake will save lots of times for other users :smiley: 